### PR TITLE
Feat: Add support for direct website installations alongside Appx

### DIFF
--- a/patch.ps1
+++ b/patch.ps1
@@ -344,6 +344,32 @@ function Find-ClaudeDir {
     return $null
 }
 
+function Find-ClaudeApp {
+	# Try at WindowsApps
+	$pkg = Find-ClaudeDir
+    if ($pkg) {
+		$AppDir = Join-Path $pkg "app"
+		if ($AppDir) { return $AppDir }
+	}
+	# Try at installed softwares
+	$uninstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    $pkg = Get-ItemProperty $uninstallKey -ErrorAction SilentlyContinue | 
+                 Where-Object { $_.DisplayName -match "Claude" -and $_.InstallLocation } | 
+                 Select-Object -First 1
+	if ($pkg) {
+		$activeVersion = $pkg.DisplayVersion
+		# Get the directory with current version .exe file
+		$claudeExe = Get-ChildItem -Path $pkg.InstallLocation -Filter "claude.exe" -Recurse -Depth 2 -ErrorAction SilentlyContinue | 
+					 Where-Object { 
+						(Test-Path (Join-Path $_.DirectoryName "resources\app.asar")) -and 
+						($_.VersionInfo.FileVersion -like "*$activeVersion*" -or $_.VersionInfo.ProductVersion -like "*$activeVersion*")
+					 } | Select-Object -First 1
+		if ($claudeExe) { return $claudeExe.DirectoryName }
+	}
+    return $null
+}
+
+
 function Stop-ClaudeServices {
     Write-Step "Halting Claude processes and services..."
     
@@ -520,11 +546,10 @@ function Install-Patch {
     Write-Host "     INSTALLING CLAUDE SMART RTL PATCH" -ForegroundColor Cyan
     Write-Host "=======================================================`n" -ForegroundColor Cyan
 
-    $ClaudeDir = Find-ClaudeDir
-    if (-not $ClaudeDir) { throw "Claude installation not found on this system." }
-    Write-Success "Found Claude at: $ClaudeDir"
-
-    $AppDir = Join-Path $ClaudeDir "app"
+	$AppDir = Find-ClaudeApp
+	if (-not $AppDir) { throw "Claude installation not found on this system." }
+    Write-Success "Found Claude app at: $AppDir"
+	
     $ResourcesDir = Join-Path $AppDir "resources"
     $AsarPath = Join-Path $ResourcesDir "app.asar"
     $ExePath = Join-Path $AppDir "claude.exe"
@@ -767,14 +792,12 @@ function Restore-Patch {
         Write-Step "Executing Fallback Rollback..."
     }
 
-    $ClaudeDir = Find-ClaudeDir
-    if (-not $ClaudeDir) { 
-        if ($IsRollback) { Write-Warn "Claude Dir not found during rollback." }
+    $AppDir = Find-ClaudeApp
+	if (-not $AppDir) { 
+        if ($IsRollback) { Write-Warn "Claude App Dir not found during rollback." }
         else { throw "Claude installation not found on this system." }
         return
     }
-    
-    $AppDir = Join-Path $ClaudeDir "app"
     $ResourcesDir = Join-Path $AppDir "resources"
     
     Stop-ClaudeServices


### PR DESCRIPTION
### Motivation
Currently, the script relies exclusively on `Get-AppxPackage` (via `Find-ClaudeDir`) to locate the Claude installation. While this works for the Windows Store version, it fails for users who downloaded the desktop app directly from Anthropic's website, which uses a standard Squirrel installer.

### Changes Made
Introduced a new locator function and updated the installation/restore flows to use it:

1. **Added `Find-ClaudeApp` function:**
   - **Appx First:** It first attempts to use the existing `Find-ClaudeDir` function. If it finds the Windows Apps installation, it returns the `app` path, preserving the original behavior.
   - **Registry Fallback:** If Appx fails, it queries the user's Registry (`HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*`) to find the standard installation.
   - **Dynamic Versioning:** To handle Squirrel updates, it matches the registry's `DisplayVersion` with the internal `FileVersion`/`ProductVersion` of the `claude.exe` binary. It also verifies that `resources\app.asar` exists alongside it.
2. **Updated Patch Flows:**
   - Replaced the calls to `Find-ClaudeDir` with `Find-ClaudeApp` inside the `Install-Patch` and `Restore-Patch` functions.

### Impact
This addition enables the patch to work for both Store and Direct-Download users without altering the core patching logic.