### PR TITLE
Isolate bare numeric/arithmetic runs LTR inside RTL text

### DIFF
--- a/src/rtl-core.js
+++ b/src/rtl-core.js
@@ -121,15 +121,117 @@ function findLatexRanges(text) {
     return ranges;
 }
 
-// Split text into alternating {type:'text'|'math', value} segments.
+// --- BARE NUMERIC / ARITHMETIC ISOLATION ---
+//
+// Claude frequently writes arithmetic WITHOUT LaTeX delimiters, e.g. a Hebrew
+// sentence containing "2 + 3 = 5". Inside an RTL paragraph the Unicode bidi
+// algorithm lays the number+operator tokens out right-to-left, so it renders
+// mirrored as "5 = 3 + 2". findMathRanges marks such runs so the DOM can isolate
+// LTR -- the same fix findLatexRanges applies to "$...$", extended to bare math.
+//
+// Operator characters whose PRESENCE proves a run is a genuine expression (not a
+// lone number, date, IP, version, or list marker). ASCII core plus common
+// Unicode math (multiply, divide, minus-sign, <=, >=, !=, ~=, arrow, dots,
+// root). Built with String.fromCharCode so the SOURCE stays pure ASCII -- the
+// patch.ps1 this is inlined into is a BOM-less .ps1, and PowerShell 5.1 corrupts
+// non-ASCII source bytes. The '-' is escaped so the string is a safe regex class
+// body. Order/codes: U+00D7 U+00F7 U+00B1 U+2212 U+2264 U+2265 U+2260 U+2248
+// U+2192 U+00B7 U+2022 U+2219 U+2217 U+22C5 U+221A.
+var MATH_OP_CHARS = '+\\-*/=<>%' + String.fromCharCode(
+    0xD7, 0xF7, 0xB1, 0x2212, 0x2264, 0x2265, 0x2260,
+    0x2248, 0x2192, 0xB7, 0x2022, 0x2219, 0x2217, 0x22C5, 0x221A);
+var MATH_OP_RE  = new RegExp('[' + MATH_OP_CHARS + ']');
+var MATH_DIGIT_RE = /[0-9]/;
+// A whitespace-delimited token is "mathy" when built only from digits and math
+// punctuation/operators, OR it is a single Latin letter used as a variable
+// (x, y, n). Multi-letter Latin tokens (English words, "3D", "4K") are NOT
+// mathy, so they break a run and keep prose out of the isolated island.
+var MATH_TOKEN_RE = new RegExp('^(?:[0-9.,:;()\\[\\]{}|' + MATH_OP_CHARS + ']+|[A-Za-z])$');
+
+function isMathyToken(tok) {
+    return !!tok && MATH_TOKEN_RE.test(tok);
+}
+
+// A token may BOUND a run only if it carries an operand -- a digit or a single
+// Latin variable letter. Pure operator/punctuation tokens ("+", "=", "(") can
+// sit inside a run but never start or end it (avoids dangling "+ 3").
+function isOperandToken(tok) {
+    return MATH_DIGIT_RE.test(tok) || /^[A-Za-z]$/.test(tok);
+}
+
+// Find bare numeric/arithmetic runs as [start, end) index pairs over `text`.
+// A run must be whitespace/line delimited, operand-bounded, and contain at least
+// one digit AND one operator. Lone numbers, "$5" currency, Hebrew-glued
+// constructs (a prefix letter joined to a number with no space), dates/IPs
+// without operators, and "1." list markers are deliberately left alone.
+function findMathRanges(text) {
+    var ranges = [];
+    if (!text || !MATH_OP_RE.test(text) || !MATH_DIGIT_RE.test(text)) return ranges;
+
+    // Scan line by line so a run never spans a newline (each line is its own
+    // bidi paragraph). `base` is the absolute offset of the current line.
+    var base = 0;
+    var lines = text.split('\n');
+    for (var li = 0; li < lines.length; li++) {
+        scanLine(lines[li], base);
+        base += lines[li].length + 1; // +1 for the '\n' removed by split
+    }
+    return ranges;
+
+    function scanLine(line, off) {
+        var toks = [];
+        var re = /\S+/g; // non-whitespace tokens; \s breaks them
+        var m;
+        while ((m = re.exec(line)) !== null) {
+            toks.push({ v: m[0], start: m.index, end: m.index + m[0].length });
+        }
+        var i = 0;
+        while (i < toks.length) {
+            if (!isMathyToken(toks[i].v)) { i++; continue; }
+            var j = i;
+            while (j + 1 < toks.length && isMathyToken(toks[j + 1].v)) j++;
+            // toks[i..j] is a maximal mathy group. Trim non-operand tokens off
+            // both ends so the isolated run is operand-bounded.
+            var a = i, b = j;
+            while (a <= b && !isOperandToken(toks[a].v)) a++;
+            while (b >= a && !isOperandToken(toks[b].v)) b--;
+            if (a <= b) {
+                var s = off + toks[a].start;
+                var e = off + toks[b].end;
+                // Drop sentence punctuation that clung to the ends (never part of
+                // a real number at a boundary: a decimal never ends in '.').
+                while (e > s && '.,:;'.indexOf(text.charAt(e - 1)) !== -1) e--;
+                while (e > s && ',:;'.indexOf(text.charAt(s)) !== -1) s++;
+                var sub = text.slice(s, e);
+                if (e - s >= 2 && MATH_DIGIT_RE.test(sub) && MATH_OP_RE.test(sub)) {
+                    ranges.push([s, e]);
+                }
+            }
+            i = j + 1;
+        }
+    }
+}
+
+// Split text into alternating {type:'text'|'math', value} segments. 'math' covers
+// both LaTeX islands (findLatexRanges) and bare arithmetic (findMathRanges); the
+// DOM layer isolates both LTR. LaTeX wins when the two overlap.
 function segmentText(text) {
     var segs = [];
     if (!text) return segs;
     var ranges = findLatexRanges(text);
+    var numeric = findMathRanges(text);
+    for (var n = 0; n < numeric.length; n++) {
+        var ns = numeric[n][0], ne = numeric[n][1], clash = false;
+        for (var c = 0; c < ranges.length; c++) {
+            if (ns < ranges[c][1] && ne > ranges[c][0]) { clash = true; break; }
+        }
+        if (!clash) ranges.push(numeric[n]);
+    }
     if (!ranges.length) {
         segs.push({ type: 'text', value: text });
         return segs;
     }
+    ranges.sort(function (a, b) { return a[0] - b[0]; });
     var pos = 0;
     for (var i = 0; i < ranges.length; i++) {
         if (ranges[i][0] > pos) {
@@ -190,6 +292,7 @@ if (typeof module !== 'undefined' && module.exports) {
         LATEX_SIGNAL: LATEX_SIGNAL,
         hasLatexSignal: hasLatexSignal,
         findLatexRanges: findLatexRanges,
+        findMathRanges: findMathRanges,
         segmentText: segmentText,
         cellDir: cellDir,
         tableDirFromCells: tableDirFromCells,

--- a/src/rtl-payload.js
+++ b/src/rtl-payload.js
@@ -123,14 +123,16 @@
             });
         }
 
-        // --- RAW LaTeX ISOLATION ---
+        // --- RAW LaTeX + BARE-ARITHMETIC ISOLATION ---
         //
         // Claude Desktop (Windows) does not render LaTeX -- it shows raw "$...$" text.
-        // Inside an RTL paragraph the neutral $ \ { } chars scramble the formula. We
-        // isolate each math segment in its own ltr/unicode-bidi:isolate span. We
-        // replace a single TEXT node with a fragment (replaceChild) -- never innerHTML
-        // -- to stay gentle on React reconciliation, and flag islands so we never
-        // re-wrap during streaming.
+        // Inside an RTL paragraph the neutral $ \ { } chars scramble the formula, and
+        // bare arithmetic ("2 + 3 = 5", "5-3", "x = 10") gets mirrored to "5 = 3 + 2"
+        // by the bidi algorithm. We isolate each math segment (LaTeX or bare numeric,
+        // per segmentText) in its own ltr/unicode-bidi:isolate span. We replace a
+        // single TEXT node with a fragment (replaceChild) -- never innerHTML -- to stay
+        // gentle on React reconciliation, and flag islands so we never re-wrap during
+        // streaming.
         var ISLAND_FLAG = 'data-rtl-island';
 
         function isolateMath(root) {
@@ -140,7 +142,13 @@
             var walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT, {
                 acceptNode: function(node) {
                     var v = node.nodeValue;
-                    if (!v || (v.indexOf('$') === -1 && v.indexOf('\\') === -1)) return NodeFilter.FILTER_REJECT;
+                    if (!v) return NodeFilter.FILTER_REJECT;
+                    // Cheap pre-filter: a LaTeX hint ($ or \), OR a numeric hint
+                    // (a digit AND an operator). MATH_DIGIT_RE / MATH_OP_RE come from
+                    // the inlined core above and are stateless (no /g flag).
+                    var hasTex = v.indexOf('$') !== -1 || v.indexOf('\\') !== -1;
+                    var hasNum = MATH_DIGIT_RE.test(v) && MATH_OP_RE.test(v);
+                    if (!hasTex && !hasNum) return NodeFilter.FILTER_REJECT;
                     var p = node.parentElement;
                     if (!p) return NodeFilter.FILTER_REJECT;
                     if (p.tagName === 'SCRIPT' || p.tagName === 'STYLE') return NodeFilter.FILTER_REJECT;

--- a/test/rtl-core.test.js
+++ b/test/rtl-core.test.js
@@ -109,3 +109,78 @@ test('stripLeadingLTR drops leading filename then detects RTL', () => {
     const stripped = core.stripLeadingLTR('foo.js שלום עולם');
     assert.strictEqual(core.firstStrong(stripped), 'rtl');
 });
+
+// --- bare numeric / arithmetic isolation (findMathRanges) ---
+
+// Helper: return the isolated substrings for a given input.
+const mathSubs = (s) => core.findMathRanges(s).map(([a, b]) => s.slice(a, b));
+
+test('findMathRanges isolates bare arithmetic inside Hebrew', () => {
+    assert.deepStrictEqual(mathSubs('התוצאה היא 2 + 3 = 5 בסך הכל'), ['2 + 3 = 5']);
+    assert.deepStrictEqual(mathSubs('הטווח הוא 5-3 מעלות'), ['5-3']);
+    assert.deepStrictEqual(mathSubs('נשאר 1/2 מהעוגה'), ['1/2']);
+    assert.deepStrictEqual(mathSubs('הצלחה של 95% מהמשתמשים'), ['95%']);
+    assert.deepStrictEqual(mathSubs('אם x = 10 אז y = 20'), ['x = 10', 'y = 20']);
+    assert.deepStrictEqual(mathSubs('no spaces 2+3=5 here'), ['2+3=5']);
+});
+
+test('findMathRanges keeps a trailing sentence period out of the island', () => {
+    assert.deepStrictEqual(mathSubs('בסך הכל 2 + 3 = 5.'), ['2 + 3 = 5']);
+    assert.deepStrictEqual(mathSubs('כך: 10 / 2 = 5, נכון'), ['10 / 2 = 5']);
+});
+
+test('findMathRanges keeps internal decimals/thousands intact', () => {
+    assert.deepStrictEqual(mathSubs('הסכום 1.5 + 2.5 = 4.0 שקלים'), ['1.5 + 2.5 = 4.0']);
+    assert.deepStrictEqual(mathSubs('יחס 3.14 * 2 בערך'), ['3.14 * 2']);
+});
+
+test('findMathRanges leaves lone numbers / dates / IPs / versions alone', () => {
+    assert.deepStrictEqual(mathSubs('יש לי 5 כלבים'), []);          // lone number
+    assert.deepStrictEqual(mathSubs('ראה עמוד 3 בספר'), []);        // lone number
+    assert.deepStrictEqual(mathSubs('הגרסה היא 1.14271.0.0 כעת'), []); // dotted version, no operator
+    assert.deepStrictEqual(mathSubs('כתובת 192.168.1.1 ברשת'), []); // IP, dots only
+    assert.deepStrictEqual(mathSubs('בשעה 12:30 נתראה'), []);       // time, colon only
+    assert.deepStrictEqual(mathSubs('1. פריט ראשון'), []);          // ordered-list marker
+});
+
+test('findMathRanges leaves currency and Hebrew-glued numbers alone', () => {
+    assert.deepStrictEqual(mathSubs('המחיר $5 + $10 בלבד'), []);    // '$' breaks the run
+    assert.deepStrictEqual(mathSubs('עולה $5.99 היום'), []);        // currency, no operator
+    assert.deepStrictEqual(mathSubs('נפגשנו ב-15 בחודש'), []);      // Hebrew-glued, no whitespace boundary
+});
+
+test('findMathRanges does not swallow surrounding English words', () => {
+    assert.deepStrictEqual(mathSubs('for 2 + 3 apples total'), ['2 + 3']);
+    assert.deepStrictEqual(mathSubs('version 2 of 3 ready'), []);   // no operator between the numbers
+});
+
+test('findMathRanges supports common Unicode operators', () => {
+    assert.deepStrictEqual(mathSubs('שטח 4 × 5 = 20'), ['4 × 5 = 20']); // x multiply, =
+    assert.deepStrictEqual(mathSubs('טמפ\' −5 ≤ 0 מעלות'), ['−5 ≤ 0']); // minus-sign, <=
+});
+
+test('findMathRanges does not cross a newline', () => {
+    assert.deepStrictEqual(mathSubs('שורה 2 + 3\nשורה 4 + 5'), ['2 + 3', '4 + 5']);
+});
+
+test('segmentText isolates bare arithmetic as a math segment', () => {
+    const segs = core.segmentText('עברית 2 + 3 = 5 עוד');
+    assert.strictEqual(segs.length, 3);
+    assert.strictEqual(segs[0].type, 'text');
+    assert.strictEqual(segs[1].type, 'math');
+    assert.strictEqual(segs[1].value, '2 + 3 = 5');
+    assert.strictEqual(segs[2].type, 'text');
+});
+
+test('segmentText: LaTeX wins over an overlapping numeric run', () => {
+    const segs = core.segmentText('נוסחה $x^2 + 1$ סוף');
+    const math = segs.filter((s) => s.type === 'math');
+    assert.strictEqual(math.length, 1);
+    assert.strictEqual(math[0].value, '$x^2 + 1$'); // not split by the inner "+ 1"
+});
+
+test('segmentText still returns single segment for currency-only text (regression)', () => {
+    const segs = core.segmentText('סתם טקסט עם $5 מחיר');
+    assert.strictEqual(segs.length, 1);
+    assert.strictEqual(segs[0].type, 'text');
+});


### PR DESCRIPTION
## Problem

The renderer already isolates **LaTeX-delimited** math (`$...$`, `$$...$$`, `\[...\]`, `\(...\)`) into `unicode-bidi:isolate;direction:ltr` islands. It does **not** handle **bare arithmetic written without delimiters**, so inside an RTL paragraph the Unicode bidi algorithm lays the number+operator tokens out right-to-left and mirrors the expression:

| Source (Hebrew) | Rendered today | Expected |
|---|---|---|
| `התוצאה היא 2 + 3 = 5` | `5 = 3 + 2` | `2 + 3 = 5` |
| `הטווח 5-3 מעלות` | `3-5` | `5-3` |
| `אם x = 10` | `10 = x` | `x = 10` |
| `4 × 5 = 20`, `1/2`, `95%` | mirrored | LTR |

## Fix

- **`src/rtl-core.js`** — add `findMathRanges(text)`: marks whitespace/line-delimited, **operand-bounded** runs that contain **≥1 digit AND ≥1 operator**. `segmentText()` now merges these with the LaTeX ranges (**LaTeX wins on overlap**), so the existing DOM isolation path wraps them into the same `[data-rtl-island]` LTR spans — no CSS changes needed.
- **`src/rtl-payload.js`** — widen the `isolateMath` TreeWalker pre-filter to also accept text nodes carrying a digit + operator (reuses the inlined `MATH_DIGIT_RE` / `MATH_OP_RE`).

### Deliberately left untouched (regression-tested)
Lone numbers (`5 כלבים`), currency (`$5.99`, `$5 + $10`), dates/IPs/versions (`192.168.1.1`, `1.14271.0.0`), times (`12:30`), ordered-list markers (`1.`), and Hebrew-glued constructs (`ב-15`). The rule requires both a digit and an operator, and runs are bounded by whitespace, so prose and English words are never swallowed.

### Known limitations (safe by design)
- Glued coefficients (`2x`) are not isolated — avoids `3D` / `4K` / `2FA` false positives.
- Letter-only algebra (`a + b`, no digit) is not isolated — Claude normally LaTeX-wraps it, which is already handled.

## ASCII safety
The new operator set uses `String.fromCharCode` so `src/rtl-core.js` stays **pure ASCII** — the BOM-less `patch.ps1` it is inlined into would otherwise be corrupted by PowerShell 5.1 reading non-ASCII source bytes.

## Tests
`node --test` → **26/26 pass** (15 existing + 11 new) covering arithmetic, decimals/thousands, ranges, `%`, `x = 10`, Unicode operators (`×`, `−`, `≤`), newline boundaries, and the regressions above.

## Build note
`patch.ps1` / `patch.ps1.sig` are **intentionally not** regenerated in this PR (the signature requires the maintainer key). After merge, run `npm run build` (`tools/build-payload.ps1`) then `tools/sign-release.ps1` to re-inline the payload and re-sign.

---
תיקון: סידור מתמטיקה ומספרים "חשופים" (בלי `$`) כך שייכתבו שמאל-לימין בתוך טקסט עברי, בלי לפגוע במחירים/תאריכים/גרסאות/מספרים בודדים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)