### PR TITLE
fix(watcher): auto-recover a hung Claude window after MSIX update / resume-from-standby

### DIFF
--- a/patch.ps1
+++ b/patch.ps1
@@ -1779,6 +1779,10 @@ $repoBase       = "https://raw.githubusercontent.com/shraga100/claude-desktop-rt
 $patchUrl       = "$repoBase/patch.ps1"
 $sigUrl         = "$repoBase/patch.ps1.sig"
 
+# Tracks when the windowed claude.exe was first seen unresponsive, so Restart-IfHung
+# only acts on a *sustained* hang (guards against transient "busy" blips).
+$script:hungSince = $null
+
 function Write-WLog($msg) {
     try {
         if (-not (Test-Path $stateDir)) { New-Item -ItemType Directory -Path $stateDir -Force | Out-Null }
@@ -1960,6 +1964,61 @@ function Test-AndPatch($exePath) {
     if ($newVer -gt $patchedVer) { Invoke-AutoPatch -newVer $newVer -exePath $exePath }
 }
 
+function Get-ClaudeAumid {
+    # Version-independent launch target. A hung process's own .Path points into
+    # the OLD versioned WindowsApps folder, which may already be removed after the
+    # MSIX update swap, so we relaunch via the app's AUMID instead.
+    try {
+        $a = Get-StartApps | Where-Object { $_.AppID -like 'Claude_*!*' } | Select-Object -First 1
+        if ($a) { return $a.AppID }
+    } catch {}
+    try {
+        $p = Get-AppxPackage -Name 'Claude*' -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($p) { return "$($p.PackageFamilyName)!Claude" }
+    } catch {}
+    return $null
+}
+
+function Restart-IfHung {
+    # Claude's MSIX self-update (often applied on resume from Modern Standby) can
+    # leave the previously-running patched claude.exe "not responding" forever --
+    # Windows logs it as Application Hang (Event 1002, MoAppHang) and the user is
+    # stuck with a frozen window that never recovers on its own. Detect a SUSTAINED
+    # hang (>=90s) and cleanly restart Claude. This never touches the signature-
+    # verify / auto-patch path. Only the process that owns a main window is checked:
+    # Responding is meaningful only for windowed processes (Electron spawns many
+    # windowless helpers that always report Responding = $true).
+    try {
+        $win = Get-Process -Name claude -ErrorAction SilentlyContinue |
+               Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1
+        if (-not $win) { $script:hungSince = $null; return }
+        if ($win.Responding) { $script:hungSince = $null; return }
+
+        if (-not $script:hungSince) {
+            $script:hungSince = [DateTime]::Now
+            Write-WLog "claude.exe (PID $($win.Id)) not responding -- watching for sustained hang."
+            return
+        }
+        if (([DateTime]::Now - $script:hungSince).TotalSeconds -lt 90) { return }
+
+        Write-WLog "claude.exe hung >90s -- killing stale processes and relaunching."
+        Get-Process -Name claude,cowork-svc -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+        $script:hungSince = $null
+        Start-Sleep -Seconds 2
+        $aumid = Get-ClaudeAumid
+        if ($aumid) {
+            Start-Process "explorer.exe" "shell:AppsFolder\$aumid" | Out-Null
+            Write-WLog "Relaunched Claude via AUMID $aumid"
+            Show-Toast "Claude was frozen" "Detected a hung Claude window (likely after an update or resume from sleep) and restarted it."
+        } else {
+            Write-WLog "Could not resolve Claude AUMID -- not relaunching."
+        }
+    } catch {
+        Write-WLog "Restart-IfHung error: $($_.Exception.Message)"
+    }
+}
+
 Write-WLog "Watcher started (PID $PID, user $env:USERNAME)"
 Write-WLog "Currently patched version: $(Get-PatchedVer)"
 
@@ -1974,8 +2033,8 @@ Register-CimIndicationEvent -Query $query -SourceIdentifier "ClaudeProcessCreate
 Write-WLog "WMI subscription active. Idling..."
 
 while ($true) {
-    $ev = Wait-Event -SourceIdentifier "ClaudeProcessCreated" -Timeout 3600
-    if ($null -eq $ev) { continue }
+    $ev = Wait-Event -SourceIdentifier "ClaudeProcessCreated" -Timeout 60
+    if ($null -eq $ev) { Restart-IfHung; continue }   # periodic hang check (~every 60s)
     try {
         $p = $ev.SourceEventArgs.NewEvent.TargetInstance.ExecutablePath
         Test-AndPatch $p


### PR DESCRIPTION
## Problem

On patched installs, Claude Desktop regularly ends up in a **permanently frozen window** that never recovers until the stale process is killed by hand. Windows logs it as **Application Hang (Event ID 1002, `MoAppHang`)** on `claude.exe`.

Event-log analysis on a live install shows a consistent pattern: the hang fires every time Claude's own **MSIX/Store self-update** rolls a new version, and it clusters right after the machine **resumes from Modern Standby**. The hang is always on the *outgoing* version and always *precedes* the watcher's detection of the new one:

```
10:56:54  Kernel-Power (507)     System is exiting Modern Standby      <- wake from sleep
10:59:42  Application Hang (1002) claude.exe 1.15962.1.0 hung           <- frozen window
11:01:50  watcher.log            "Detected Claude v1.17377.1.0 ..."     <- watcher reacts AFTER
```

| Hang (Event 1002)   | Version that hung | Next watcher patch     |
|---------------------|-------------------|------------------------|
| 2026-06-12 01:51:55 | 1.11847.5.0       | 01:52:30 → 1.12603     |
| 2026-06-19 17:25:15 | 1.13576.4.0       | 17:26:29 → 1.14271     |
| 2026-06-24 03:03:04 | 1.14271.0.0       | 03:05:20 → 1.15200     |
| 2026-07-01 10:59:42 | 1.15962.1.0       | 11:01:50 → 1.17377     |

Root cause is Claude's MSIX self-update applied while the old, still-running instance is live — outside the patch's control. But the watcher only reacts when a **new** `claude.exe` appears, so the hung instance is never cleaned up automatically. (Possible aggravator worth confirming: the patch modifies files in-place under `WindowsApps` and re-signs the binaries, so `Get-AppxPackage` reports `SignatureKind = Developer`; a tampered package may make Windows' update-apply path more aggressive than for a pristine Store package.)

## Change

Adds a periodic hang check to the watcher (embedded as the here-string in `patch.ps1`):

- On each idle tick, inspect the `claude.exe` process that owns a main window (`MainWindowHandle -ne 0`). `Responding` is only meaningful for windowed processes — Electron spawns many windowless helpers that always report `Responding = $true`.
- If it is unresponsive for a **sustained** window (≥90s, to avoid false positives from transient busy blips), force-kill the stale `claude` / `cowork-svc` processes and relaunch Claude via its **AUMID** (`shell:AppsFolder\Claude_pzs8sxrjxfjjc!Claude`) — version-independent, so it survives the `WindowsApps` folder swap.
- Idle-loop timeout drops `3600 → 60` so recovery kicks in within ~1–2 min.

The signature-verification / auto-patch path is **untouched**. No re-patch loop: a same-version relaunch has `newVer == patchedVer`, so `Invoke-AutoPatch` is not triggered.

## Notes / testing

- Verified on a live install: exactly one `claude.exe` owns a main window; helpers report no window. AUMID resolves via `Get-StartApps` → `Claude_pzs8sxrjxfjjc!Claude`, and `Start-Process explorer.exe "shell:AppsFolder\<AUMID>"` launches the MSIX app.
- The extracted watcher here-string passes `[PSParser]::Tokenize` with no errors. `patch.ps1` kept LF / no-BOM per `.gitattributes`.
- **Not yet validated end-to-end against a forced 1002 hang** (couldn't reliably reproduce one on demand) — please sanity-check on a real hang before release.
- ⚠️ **`patch.ps1` changed → it must be re-signed** (`tools/sign-release.ps1`) and committed together with `patch.ps1.sig` before release. This PR intentionally does **not** touch `patch.ps1.sig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
